### PR TITLE
Move click to action chain

### DIFF
--- a/basepage/base_page.py
+++ b/basepage/base_page.py
@@ -250,13 +250,12 @@ class BasePage(object):
         if not isinstance(element, WebElement):
             element = self.get_visible_element(locator, params)
 
-        if with_click:
-            self.click(element)
-
         actions = ActionChains(self.driver)
         if 'explorer' in self.driver.name and "@" in str(text):
             actions = BasePage.handle_at_sign_for_ie(text, actions)
         else:
+            if with_click:
+                actions.click(element)
             actions.send_keys_to_element(element, text)
 
         if with_clear:


### PR DESCRIPTION
Move the click to action chain instead of clicking it via regular element click. This keeps the actions atomic and also handles weird bug where the focus from text box jumps in legacy/older for various rendering reasons.