### PR TITLE
Fix when exp_cond doesn't return a WebElement

### DIFF
--- a/basepage/base_page.py
+++ b/basepage/base_page.py
@@ -575,7 +575,11 @@ class BasePage(object):
         exp_cond = expected_condition(locator, **kwargs)
         if timeout == 0:
             try:
-                return exp_cond(_driver)
+                exp_cond_result = exp_cond(_driver)
+                # Only return if we get a real WebElement back, otherwise we want to pass the
+                # result downwards to the WebDriverWait().until() function, be it False, None, or otherwise
+                if isinstance(exp_cond_result, WebElement):
+                    return exp_cond_result
             except NoSuchElementException:
                 return None
 

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from distutils.core import setup
 setup(
     name='basepage',
     packages=['basepage'],
-    version='1.7.4',
+    version='1.7.5',
     description='A wrapper for WebDriver that provides some extended and additional functionality',
     author='Bijwen Aziz',
     author_email='baziz@planview.com',
     url='https://github.com/Projectplace/basepage',
-    download_url='https://github.com/Projectplace/basepage/tarball/1.7.4',
+    download_url='https://github.com/Projectplace/basepage/tarball/1.7.5',
     keywords=['testing', 'webdriver', 'selenium'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from distutils.core import setup
 setup(
     name='basepage',
     packages=['basepage'],
-    version='1.7.5',
+    version='1.7.4',
     description='A wrapper for WebDriver that provides some extended and additional functionality',
     author='Bijwen Aziz',
     author_email='baziz@planview.com',
     url='https://github.com/Projectplace/basepage',
-    download_url='https://github.com/Projectplace/basepage/tarball/1.7.5',
+    download_url='https://github.com/Projectplace/basepage/tarball/1.7.4',
     keywords=['testing', 'webdriver', 'selenium'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
exp_cond can sometimes return False instead of a WebElement when
the exp_cond fails, we then do not want to return the bool - we just
want to continue onwards with the _get method